### PR TITLE
Add GitHub links, accessibility icon text

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -19,6 +19,8 @@ website:
       href: LICENSE.md
     - text: "Code of Conduct"
       href: CODE_OF_CONDUCT.md
+    - text: "Edit on GitHub"
+      href: "https://github.com/datascijedi/website"
 
   page-navigation: true
 
@@ -41,13 +43,20 @@ website:
 
     right:
       - icon: twitter
-        file: https://twitter.com/datascijedi
+        href: https://twitter.com/datascijedi
+        aria-label: Twitter
       - icon: linkedin
-        file: https://www.linkedin.com/showcase/justice-equity-diversity-and-inclusion-organizing-group
+        href: https://www.linkedin.com/showcase/justice-equity-diversity-and-inclusion-organizing-group
+        aria-label: LinkedIn
       - icon: instagram
-        file: https://www.instagram.com/datascijedi/
+        href: https://www.instagram.com/datascijedi/
+        aria-label: Instagram
       - icon: facebook
-        file: https://www.facebook.com/DataSciJEDI/
+        href: https://www.facebook.com/DataSciJEDI/
+        aria-label: Facebook
+      - icon: github
+        href: https://github.com/datascijedi/website
+        aria-label: GitHub
 
   sidebar:
     - id: about

--- a/about.qmd
+++ b/about.qmd
@@ -17,7 +17,7 @@ about:
       href: https://www.facebook.com/DataSciJEDI/
     - icon: github
       text: GitHub
-      href: https://github.com/datascijedi
+      href: https://github.com/datascijedi/website
 sidebar: false
 ---
 


### PR DESCRIPTION
Related Issue: #16 

Primary Updates:

- Added GitHub icon to the top right
- Added "Edit on GitHub" text link to bottom right

Secondary Updates:

- Changed "file:" to "href:" for clarity, for all top right icons
- Added accessibility labels for top right icons (with `aria-label`)
- Changed GitHub link on about page to point directly to the repo

Additional Info:

Let me know if you think the top right is too crowded with the GitHub icon, I went back and forth on this and ended up including it for now. 
