### PR TITLE
Page-specific GitHub edit link

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -1,6 +1,8 @@
 project:
   type: website
 
+  post-render: dynamic_github_edit.js
+
 website:
   title: "DataSci JEDI"
   description: "The Justice, Equity, Diversity, and Inclusion (JEDI) Outreach Group, a community of statisticians and data scientists, is committed to communication, programming, and professional development to advance and support a society that values all people."
@@ -14,13 +16,13 @@ website:
 
   page-footer:
     left: "Copyright 2022 © JEDI"
+    center:
+    - text: "GH-6c622c2fa6a54817" # placeholder text, replaced in post-render script
     right:
     - text: "License"
       href: LICENSE.md
     - text: "Code of Conduct"
       href: CODE_OF_CONDUCT.md
-    - text: "Edit on GitHub"
-      href: "https://github.com/datascijedi/website"
 
   page-navigation: true
 

--- a/dynamic_github_edit.js
+++ b/dynamic_github_edit.js
@@ -1,8 +1,8 @@
 // This script inserts a page-specific GitHub edit link in the footer of HTML files
 
 // Set paths
-var source_path = '.'
-var build_path = './_site'
+var source_path = '.';
+var build_path = './_site';
 
 // Prepare list of source file names
 var source_files_raw = Array.from((Deno.readDirSync(source_path)));
@@ -12,13 +12,13 @@ for (const sf of source_files_raw) {
 }
 
 // Prepare for string replacement
-var string_to_replace = 'GH-6c622c2fa6a54817' // placeholder set in _quarto.yml
+var string_to_replace = 'GH-6c622c2fa6a54817'; // placeholder set in _quarto.yml
 var dynamic_gh_html_pre = '<div>' + 
-                          '<p><a href="'
+                          '<p><a href="';
 var dynamic_gh_html_post = '"><div><i class="bi bi-github"></i></div>Edit this page</a></p>' +
-                           '</div>'
+                           '</div>';
 var dynamic_gh_html_post_fallback = '"><div><i class="bi bi-github"></i></div>Edit on GitHub</a></p>' +
-                                    '</div>'
+                                    '</div>';
 
 // Loop through build files and insert "Edit this page" into HTML files
 let build_files = Deno.readDirSync(build_path);
@@ -31,7 +31,7 @@ for (const f of build_files) {
     let f_split = f.name.split('.');
     if (f_split.length < 2) continue;
     if (f_split[1].toLowerCase() != 'html') continue;
-    let f_without_ext = f_split[0]    
+    let f_without_ext = f_split[0];    
     // Determine GitHub link based on source file type
     if (source_file_names.includes(f_without_ext + '.qmd')) {
         source_file = source_path + f_without_ext + '.qmd';
@@ -53,17 +53,17 @@ for (const f of build_files) {
     let replacement_string;
     let dynamic_gh_link;
     if (fallback) {
-        dynamic_gh_link = `https://github.com/datascijedi/website`
+        dynamic_gh_link = `https://github.com/datascijedi/website`;
         replacement_string = dynamic_gh_html_pre + dynamic_gh_link + dynamic_gh_html_post_fallback;
     }
     else {
         if (source_file.charAt(0) == '.') source_file = source_file.slice(1);
-        dynamic_gh_link = `https://github.com/datascijedi/website/edit/main/${source_file}`
+        dynamic_gh_link = `https://github.com/datascijedi/website/edit/main/${source_file}`;
         replacement_string = dynamic_gh_html_pre + dynamic_gh_link + dynamic_gh_html_post;
     }
     let build_file_path = build_path + '/' + f.name;
     let file_bytes_in = Deno.readFileSync(build_file_path);
-    let file_string_in = decoder.decode(file_bytes_in)
+    let file_string_in = decoder.decode(file_bytes_in);
     let file_string_out = file_string_in.replace(string_to_replace, replacement_string);
     let file_bytes_out = encoder.encode(file_string_out);
     Deno.writeFileSync(build_file_path, file_bytes_out);

--- a/dynamic_github_edit.js
+++ b/dynamic_github_edit.js
@@ -17,12 +17,15 @@ var dynamic_gh_html_pre = '<div>' +
                           '<p><a href="'
 var dynamic_gh_html_post = '"><div><i class="bi bi-github"></i></div>Edit this page</a></p>' +
                            '</div>'
+var dynamic_gh_html_post_fallback = '"><div><i class="bi bi-github"></i></div>Edit on GitHub</a></p>' +
+                                    '</div>'
 
 // Loop through build files and insert "Edit this page" into HTML files
 let build_files = Deno.readDirSync(build_path);
 const decoder = new TextDecoder("utf-8");
 const encoder = new TextEncoder("utf-8");
 let source_file;
+let fallback = false;
 for (const f of build_files) {
     if (!f.isFile) continue;
     let f_split = f.name.split('.');
@@ -44,12 +47,20 @@ for (const f of build_files) {
     }
     else {
         console.error(`No source file found for HTML build file: ${f}`);
-        continue;
+        fallback = true;
     }
-    if (source_file.charAt(0) == '.') source_file = source_file.slice(1);
-    let dynamic_gh_link = `https://github.com/datascijedi/website/edit/main/${source_file}`
     // Insert the GitHub link
-    let replacement_string = dynamic_gh_html_pre + dynamic_gh_link + dynamic_gh_html_post;
+    let replacement_string;
+    let dynamic_gh_link;
+    if (fallback) {
+        dynamic_gh_link = `https://github.com/datascijedi/website`
+        replacement_string = dynamic_gh_html_pre + dynamic_gh_link + dynamic_gh_html_post_fallback;
+    }
+    else {
+        if (source_file.charAt(0) == '.') source_file = source_file.slice(1);
+        dynamic_gh_link = `https://github.com/datascijedi/website/edit/main/${source_file}`
+        replacement_string = dynamic_gh_html_pre + dynamic_gh_link + dynamic_gh_html_post;
+    }
     let build_file_path = build_path + '/' + f.name;
     let file_bytes_in = Deno.readFileSync(build_file_path);
     let file_string_in = decoder.decode(file_bytes_in)

--- a/dynamic_github_edit.js
+++ b/dynamic_github_edit.js
@@ -1,0 +1,65 @@
+// This script inserts the page-specific GitHub edit link in the footer
+
+// To Do: need to clean up code
+
+// Prepare list of source files
+var source_path = '.'
+var source_files = Deno.readDirSync(source_path);
+var source_files_array = Array.from(source_files);
+var source_files_array_clean = Array();
+for (const sf of source_files_array) {
+    source_files_array_clean.push(sf.name);
+}
+
+// Prepare for string replacement
+var string_to_replace = 'GH-6c622c2fa6a54817'
+var dynamic_gh_html_pre = '<div>' + 
+                    '<p><a href="'
+var dynamic_gh_html_post = '"><div><i class="bi bi-github"></i></div>Edit this page</a></p>' +
+                            '</div>'
+
+// Find HTML build files and insert "Edit this page"
+var build_path = './_site'
+var build_files = Deno.readDirSync(build_path);
+for (const f of build_files) {
+    if (!f.isFile) continue;
+    let f_split = f.name.split('.');
+    let f_without_ext = f_split[0]
+    let f_build_ext = f_split[1]
+    if (f_build_ext.toLowerCase() != 'html') continue;
+    const decoder = new TextDecoder("utf-8");
+    const encoder = new TextEncoder("utf-8");
+
+    if (source_files_array_clean.includes(f_without_ext + '.qmd')) {
+        // to do: declare variables outside of if-block
+        let source_file = source_path + f_without_ext + '.qmd';
+        source_file = source_file.slice(1); // make this conditional upon a starting period? 
+        let dynamic_gh_link = `https://github.com/datascijedi/website/edit/main/${source_file}`
+        let replacement_string = dynamic_gh_html_pre + dynamic_gh_link + dynamic_gh_html_post
+
+        // to do: abstract this to a function perhaps
+        let build_file_path = build_path + '/' + f.name;
+        let file_bytes = Deno.readFileSync(build_file_path);
+        let file_string = decoder.decode(file_bytes)
+        file_string = file_string.replace(string_to_replace, replacement_string);
+        let file_bytes_out = encoder.encode(file_string);
+        Deno.writeFileSync(build_file_path, file_bytes_out);
+    }
+    else if (source_files_array_clean.includes(f_without_ext + '.md')) {
+        let source_file = source_path + f_without_ext + '.md';
+        source_file = source_file.slice(1); // make this conditional upon a starting period? 
+        let dynamic_gh_link = `https://github.com/datascijedi/website/edit/main/${source_file}`
+        let replacement_string = dynamic_gh_html_pre + dynamic_gh_link + dynamic_gh_html_post
+
+        // to do: abstract this to a function perhaps
+        let build_file_path = build_path + '/' + f.name;
+        let file_bytes = Deno.readFileSync(build_file_path);
+        let file_string = decoder.decode(file_bytes)
+        file_string = file_string.replace(string_to_replace, replacement_string);
+        let file_bytes_out = encoder.encode(file_string);
+        Deno.writeFileSync(build_file_path, file_bytes_out);
+    }
+    else {
+        console.error(`No source file found for ${f}`)
+    }
+}


### PR DESCRIPTION
Related Issue: #25

This PR implements a page-specific GitHub edit link. 

At a high-level, first a unique placeholder is put in the footer, then the script replaces that with a link to edit the source file. 