### PR TITLE
Updates to gh post-render script

### DIFF
--- a/dynamic_github_edit.js
+++ b/dynamic_github_edit.js
@@ -8,7 +8,7 @@ const build_path_list = ['./_site', './_site/webinars', './_site/webinars/past',
 
 // Prepare list of source file names
 const source_files_raw = Array.from((Deno.readDirSync(source_path)));
-const source_file_names = Array();
+const source_file_names = [];
 for (const sf of source_files_raw) {
     source_file_names.push(sf.name);
 }

--- a/dynamic_github_edit.js
+++ b/dynamic_github_edit.js
@@ -3,37 +3,34 @@
 // paths to find the corresponding source files.
 
 // Set paths
-var source_path = '.';
-var build_path_list = ['./_site', './_site/webinars', './_site/webinars/past', './_site/webinars/upcoming'];
+const source_path = '.';
+const build_path_list = ['./_site', './_site/webinars', './_site/webinars/past', './_site/webinars/upcoming'];
 
 // Prepare list of source file names
-var source_files_raw = Array.from((Deno.readDirSync(source_path)));
-var source_file_names = Array();
+const source_files_raw = Array.from((Deno.readDirSync(source_path)));
+const source_file_names = Array();
 for (const sf of source_files_raw) {
     source_file_names.push(sf.name);
 }
 
 // Prepare for string replacement
-var string_to_replace = 'GH-6c622c2fa6a54817'; // placeholder set in _quarto.yml
-var dynamic_gh_html_pre = '<div>' +
+const string_to_replace = 'GH-6c622c2fa6a54817'; // placeholder set in _quarto.yml
+const dynamic_gh_html_pre = '<div>' +
                           '<p><a aria-label="Edit this page" href="';
-var dynamic_gh_html_post = '">Edit this page</a></p>' +
-                           '</div>';
-var dynamic_gh_html_post_fallback = '">Edit on GitHub</a></p>' +
-                                    '</div>';
-
+const dynamic_gh_html_post = '">Edit this page</a></p>' + '</div>';
+const dynamic_gh_html_post_fallback = '">Edit on GitHub</a></p>' + '</div>';
 
 // Loop through build files and insert "Edit this page" into HTML files
 for (const build_path of build_path_list) {
-    let build_files = Deno.readDirSync(build_path);
+    const build_files = Deno.readDirSync(build_path);
     let source_file;
     let fallback = false;
     for (const f of build_files) {
         if (!f.isFile) continue;
-        let f_split = f.name.split('.');
+        const f_split = f.name.split('.');
         if (f_split.length < 2) continue;
         if (f_split[1].toLowerCase() != 'html') continue;
-        let f_without_ext = f_split[0];
+        const f_without_ext = f_split[0];
         // Determine GitHub link based on source file type
         if (source_file_names.includes(f_without_ext + '.qmd')) {
             source_file = source_path + f_without_ext + '.qmd';
@@ -63,9 +60,9 @@ for (const build_path of build_path_list) {
             dynamic_gh_link = `https://github.com/datascijedi/website/edit/main/${source_file}`;
             replacement_string = dynamic_gh_html_pre + dynamic_gh_link + dynamic_gh_html_post;
         }
-        let build_file_path = build_path + '/' + f.name;
-        let file_string_in = Deno.readTextFileSync(build_file_path);
-        let file_string_out = file_string_in.replace(string_to_replace, replacement_string);
+        const build_file_path = build_path + '/' + f.name;
+        const file_string_in = Deno.readTextFileSync(build_file_path);
+        const file_string_out = file_string_in.replace(string_to_replace, replacement_string);
         Deno.writeTextFileSync(build_file_path, file_string_out);
     }
 }

--- a/dynamic_github_edit.js
+++ b/dynamic_github_edit.js
@@ -15,10 +15,9 @@ for (const sf of source_files_raw) {
 
 // Prepare for string replacement
 const string_to_replace = 'GH-6c622c2fa6a54817'; // placeholder set in _quarto.yml
-const dynamic_gh_html_pre = '<div>' +
-                          '<p><a aria-label="Edit this page" href="';
-const dynamic_gh_html_post = '">Edit this page</a></p>' + '</div>';
-const dynamic_gh_html_post_fallback = '">Edit on GitHub</a></p>' + '</div>';
+const dynamic_gh_html_pre = '<a class="nav-link" aria-label="Edit this page" href="';
+const dynamic_gh_html_post = '">Edit this page</a>';
+const dynamic_gh_html_post_fallback = '">Edit on GitHub</a>';
 
 // Loop through build files and insert "Edit this page" into HTML files
 for (const build_path of build_path_list) {

--- a/dynamic_github_edit.js
+++ b/dynamic_github_edit.js
@@ -23,11 +23,9 @@ var dynamic_gh_html_post_fallback = '">Edit on GitHub</a></p>' +
                                     '</div>';
 
 
+// Loop through build files and insert "Edit this page" into HTML files
 for (const build_path of build_path_list) {
-    // Loop through build files and insert "Edit this page" into HTML files
     let build_files = Deno.readDirSync(build_path);
-    const decoder = new TextDecoder("utf-8");
-    const encoder = new TextEncoder("utf-8");
     let source_file;
     let fallback = false;
     for (const f of build_files) {
@@ -66,10 +64,8 @@ for (const build_path of build_path_list) {
             replacement_string = dynamic_gh_html_pre + dynamic_gh_link + dynamic_gh_html_post;
         }
         let build_file_path = build_path + '/' + f.name;
-        let file_bytes_in = Deno.readFileSync(build_file_path);
-        let file_string_in = decoder.decode(file_bytes_in);
+        let file_string_in = Deno.readTextFileSync(build_file_path);
         let file_string_out = file_string_in.replace(string_to_replace, replacement_string);
-        let file_bytes_out = encoder.encode(file_string_out);
-        Deno.writeFileSync(build_file_path, file_bytes_out);
+        Deno.writeTextFileSync(build_file_path, file_string_out);
     }
 }


### PR DESCRIPTION
For the gh link post-render script:

Addresses GitHub link vertical alignment in footer as discussed in issue #35, lints post-render script, and simplifies the script by using Deno's built-in text reader/writer. 