### PR TITLE
Add Netlify deploy workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,32 +1,80 @@
+name: Website Deploy
 on:
   workflow_dispatch:
   push:
-    branches: main
+    branches: 
+      - netlify-deploy-prep
   pull_request:
-    branches: main
-
-name: Quarto Publish
-
+    branches: 
+      - netlify-deploy-prep
+    type:
+      - opened
+      - synchronize
 jobs:
-  build-deploy:
+  netlify-deploy-preview:
+    name: Netlify Deploy Preview
+    if: github.event_name == 'pull_request' && github.base_ref == 'netlify-deploy-prep'
     runs-on: ubuntu-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+      - name: Set up Quarto
+        uses: quarto-dev/quarto-actions/setup@v2
+      - name: Render Quarto project
+        uses: quarto-dev/quarto-actions/render@v2
+      - name: Deploy to Netlify
+        id: netlify-deploy-step
+        uses: nwtgck/actions-netlify@v1.2
+        with:
+          publish-dir: '_site'
+          production-deploy: false
+          deploy-message: "Deploy Preview from GitHub Actions"
+          enable-pull-request-comment: false
+          enable-commit-comment: false
+          overwrites-pull-request-comment: false
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN_TEST_RM }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID_TEST_RM }}
+        timeout-minutes: 1
+      - name: Add deploy preview link to PR comments
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: |
+            Deploy preview: ${{ steps.netlify-deploy-step.outputs.deploy-url }}
+  netlify-production-deploy:
+    name: Netlify Production Deploy
+    if: |
+      (github.event_name == 'push' && github.ref_name == 'netlify-deploy-prep')
+      || (github.event_name == 'workflow_dispatch' && github.ref_name == 'netlify-deploy-prep')
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
-
+        uses: actions/checkout@v3
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
-
       - name: Render Quarto Project
         uses: quarto-dev/quarto-actions/render@v2
-
-      - name: Deploy 🚀
-        if: github.event_name != 'pull_request'
+      - name: Deploy to Netlify
+        uses: nwtgck/actions-netlify@v1.2
+        with:
+          publish-dir: '_site'
+          production-deploy: true
+          deploy-message: "Production Deploy from GitHub Actions"
+          enable-pull-request-comment: false
+          enable-commit-comment: false
+          overwrites-pull-request-comment: false
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN_TEST_RM }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID_TEST_RM }}
+        timeout-minutes: 1
+      - name: Deploy to Branch `netlify-deploy-prep-build` # to view build files on GitHub
         uses: JamesIves/github-pages-deploy-action@4.1.7
         with:
-          branch: gh-pages # The branch the action should deploy to.
           folder: _site # The folder the action should deploy.
+          branch: netlify-deploy-prep-build # The branch the action should deploy to.
+        timeout-minutes: 1


### PR DESCRIPTION
Hi All - this PR contains a workflow to deploy the new website to Netlify. A few updates will be needed for making it live, e.g. using the `main` branch in the GitHub workflow rather than `netlify-deploy-prep`, but otherwise is ready and available here for review. 

At a high-level: The workflow will deploy from a source branch (e.g. `main`) to a deploy branch (e.g. `main-build`), then push to the Netlify instance. The workflow also will also create deploy previews for pull requests to the `main` branch and then insert the deploy preview link as a comment on the pull request. 