### PR TITLE
Add dummy webinar to render exceptions

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -9,6 +9,7 @@ project:
     - "*.Rmd"
     - "!CONTRIBUTING.md"
     - "!render_scripts/data/README-gh-pages.md"
+    - "!webinars/dummy-webinar-page.qmd"
 
   post-render:
     - render_scripts/copy_gh_pages_readme.ts


### PR DESCRIPTION
Add dummy webinar to render exceptions so that an HTML file for dummy webinar is not created. 