### PR TITLE
Add a default port for `quarto preview`

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -1,6 +1,8 @@
 project:
   type: website
   output-dir: _site
+  preview:
+    port: 4200
 
   render:
     - "*.qmd"


### PR DESCRIPTION
Set the default port to `4200` in this commit  so that `quarto preview` will use this by default. Just wanted to make sure there are no conflicts (e.g. if folks are running other servers on `localhost:4200`). 