### PR TITLE
Use a workaround to fix the missing footer border

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -6,7 +6,6 @@
   margin-right: 15px;
 }
 
-
 @media screen and (max-width: 767px) {
   .hide-twitter-timeline {
     visibility: hidden;
@@ -56,4 +55,13 @@
   right: 0;
   width: 100%;
   height: 100%;
+}
+
+/*
+Using a floating `sidebar` in Quarto sets the `floating` class on the `body` element, which in turn
+causes bootstrap to not apply `border-top` to `nav-footer`, so we use this work around to
+make the footer border always appear.
+*/
+body .nav-footer {
+  border-top: 1px solid #dee2e6;
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -56,12 +56,3 @@
   width: 100%;
   height: 100%;
 }
-
-/*
-Using a floating `sidebar` in Quarto sets the `floating` class on the `body` element, which in turn
-causes bootstrap to not apply `border-top` to `nav-footer`, so we use this work around to
-make the footer border always appear.
-*/
-body .nav-footer {
-  border-top: 1px solid #dee2e6;
-}

--- a/css/styles.css
+++ b/css/styles.css
@@ -56,3 +56,12 @@
   width: 100%;
   height: 100%;
 }
+
+/*
+Using a floating `sidebar` in Quarto sets the `floating` class on the `body` element, which in turn
+causes bootstrap to not apply `border-top` to `nav-footer`, so we use this work around to
+make the footer border always appear.
+*/
+body .nav-footer {
+  border-top: 1px solid #dee2e6;
+}


### PR DESCRIPTION
Addresses issue #78. 

Using a floating `sidebar` in Quarto sets the `floating` class on the `body` element, which in turn causes bootstrap to not apply `border-top` to `nav-footer`, causing the footer border not to appear on the "Activities" page. 

This workaround uses custom css to make the footer border always appear. 

This is probably a Quarto bug. It's also worth noting, we have other experienced other quirky side bar behavior in PR #74 and PR #23. 