### PR TITLE
Add workaround for "Activities" sidebar separator

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -80,6 +80,7 @@ website:
   sidebar:
     # We use a dummy sidebar so that pages without a sidebar don't inherit an actual sidebar
     - id: dummy-sidebar
+      border: true # Causes the separator to appear for the "Activities" sidebar
     - title: "Activities"
       style: "floating"
       collapse-level: 2


### PR DESCRIPTION
This workaround brings back the side bar separator even when using a floating separator and addresses a quirk we came across in PR #23. 