### PR TITLE
Include page titles in Twitter cards

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -42,7 +42,6 @@ website:
   twitter-card:
     card-style: summary
     site: "@datascijedi"
-    title: "JEDI Outreach Group"
     description: "The Justice, Equity, Diversity, and Inclusion (JEDI) Outreach Group, a community of statisticians and data scientists, is committed to communication, programming, and professional development to advance and support a society that values all people."
     image: "images/jedi-logo-square.png"
 

--- a/activities.qmd
+++ b/activities.qmd
@@ -1,5 +1,5 @@
 ---
-title: "JEDI Outreach Group Committees"
+title: "Committees"
 ---
 
 Our committees are actively working to promote justice, equity, diversity, and inclusion (JEDI) principles in statistics and data science. 

--- a/index.qmd
+++ b/index.qmd
@@ -1,4 +1,5 @@
 ---
+pagetitle: "JEDI Outreach Group"
 toc: false
 sidebar: false
 listing:


### PR DESCRIPTION
Added or edited title metadata wherever needed to present well for Twitter cards and page titles.

By removing `twitter-card: title:` from `_quarto.yml`, the Twitter card title metadata is grabbed from `website title - page title`, as explained at https://github.com/quarto-dev/quarto-cli/issues/5263. 