### PR TITLE
Twitter timeline temp fix

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -17,14 +17,16 @@ listing:
     sort: "date desc"
 ---
 
-::: column-margin
+<!-- Temporarily removing the embedded Twitter feed, see discussion here: 
+https://twittercommunity.com/t/again-list-widget-says-nothing-to-see-here-yet-if-logged-out/198782/111 -->
+<!-- ::: column-margin
 ```{=html}
 <div class="hide-twitter-timeline">
   <a class="twitter-timeline" data-width="350" data-tweet-limit="2" float="right" href="https://twitter.com/DataSciJedi?ref_src=twsrc%5Etfw">Tweets by DataSciJedi</a> 
   <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 </div>
 ```
-:::
+::: -->
 
 ```{=html}
 <img src="images/jedi-logo-wide.png" alt="Logo of the Justice, Equity, Diversity, and Inclusion Outreach Group" class="center">
@@ -68,15 +70,14 @@ Sign-up for your free membership to the JEDI Outreach Group.
 
 [Become a JEDI member](get-involved.qmd){.button .button1 .center}
 
-::: {.show-twitter-timeline}
-
+<!-- Temporarily removing the embedded Twitter feed, see discussion here: 
+https://twittercommunity.com/t/again-list-widget-says-nothing-to-see-here-yet-if-logged-out/198782/111 -->
+<!-- ::: {.show-twitter-timeline}
 ## Twitter Feed
-
 ```{=html}
 <center>
   <a class="twitter-timeline" data-width="350" data-tweet-limit="2" float="center" href="https://twitter.com/DataSciJedi?ref_src=twsrc%5Etfw">Tweets by DataSciJedi</a> 
   <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 </center>
 ```
-
-:::
+::: -->

--- a/templates/jedi-corner-home.ejs
+++ b/templates/jedi-corner-home.ejs
@@ -2,9 +2,9 @@
 <div class="list">
   <% for (const item of items) { %>
     <div <%= metadataAttrs(item) %>>
-      <div class="style">
+      <div class="jedi-list-item">
         <style>
-          img {
+          .jedi-list-item img {
             float: left;
             margin-top: 6px;
             margin-right: 15px;


### PR DESCRIPTION
This is a temporary fix for issue #100. We remove (comment out) the embedded Twitter timeline, which is currently broken. 

A small fix to the CSS in `templates/jedi-corner-home.ejs` is made along the way as well here. This ensures the alignment of the home page's elements work as expected after removing the Twitter timeline. 

fyi @rycoley