### PR TITLE
Accessibility updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@ We welcome and value contributions from everyone. Contributions can include addi
   - [Updating Resources](#updating-resources)
   - [Updating Webinars](#updating-webinars)
   - [JEDI Corner](#jedi-corner)
+  - [Accessibility Tips](#accessibility-tips)
 - [Development](#development)
   - [Setup](#setup)
   - [Deployment](#deployment)
@@ -64,6 +65,41 @@ Each month, update website with a new JEDI corner article.
 
 1) Save photo of author or article image to images/jedi-corner  
 2) In jedi-corner.yml, copy entry from previous month. Edit article information, Committ changes.
+
+### Accessibility Tips
+
+Accessibility is too large a topic to be completely covered here, but below are a few tips and examples for content editors to use. In particular, try to use `alt`, `aria-label`, or similar tags appropriately when adding images or links to the website. 
+
+#### Example 1
+
+When inserting an image with HTML, the `alt` tag can help convey the image's contents to screen reader users. 
+
+`<img src="images/jedi-logo-wide.png" alt="Logo of the Justice, Equity, Diversity, and Inclusion Outreach Group">`
+
+#### Example 2
+
+When inserting images with Quarto markdown syntax, the `fig-alt` attribute can be used for adding alt text. 
+
+`![](images/jedi-at-jsm/schedule-no0069Or1614Sessions.png){fig-alt="A schedule graphic depicting..."}`
+
+This also applies if your image is wrapped further in a markdown hyperlink. 
+
+`[![](images/jedi-at-jsm/schedule-no0069Or1614Sessions.png){fig-alt="A schedule graphic depicting..."}](images/jedi-at-jsm/schedule-no0069Or1614Sessions.png)`
+
+#### Example 3
+
+An `aria-label` can help make a link's purpose clearer to screen reader users. 
+
+`<a class="nav-link" aria-label="Edit this Page on GitHub" href="https://github.com/datascijedi">Edit on GitHub</a>;`
+
+#### Additional Resources
+
+Here are a few resources you can use to learn more about accessibility:
+
+- [Berkeley Web Accessibility Tips](https://webaccess.berkeley.edu/resources/tips/web-accessibility)
+- [Firefox - Accessibliity Inspector](https://firefox-source-docs.mozilla.org/devtools-user/accessibility_inspector/)
+- [Axe Dev Tools](https://www.deque.com/axe/devtools/)
+- [Thorough Reference on Accessibility](https://www.section508.gov/content/guide-accessible-web-design-development/)
 
 ## Development
 

--- a/css/darkstyle.scss
+++ b/css/darkstyle.scss
@@ -6,6 +6,12 @@ $font-family: "Atkinson Hyperlegible", sans-serif;
 
 $link-color: #4fd1b8;
 
+// Update contrast for accessiblity
+$pagination-bg: #4dd9bd;
+$pagination-color: #0b0b0b;
+$pagination-active-bg: #07eec0;
+$pagination-active-color: #0b0b0b;
+
 /*-- scss:rules --*/
 
 .button {
@@ -47,4 +53,10 @@ $link-color: #4fd1b8;
     padding-bottom: 5px;
     background-color: #375a7f;
   }
+}
+
+// The override with $pagination-active-color is not working for the active link on dark theme,
+// so we manually override it here
+ul.pagination li.active a {
+  color: #0b0b0b;
 }

--- a/css/lightstyle.scss
+++ b/css/lightstyle.scss
@@ -6,6 +6,14 @@ $font-family: "Atkinson Hyperlegible", sans-serif;
 
 $link-color: #0B5B4B;
 
+// Update contrast for accessiblity
+$pagination-bg: #4dd9bd;
+$pagination-color: #0b0b0b;
+$pagination-active-bg: #07eec0;
+$pagination-active-color: #0b0b0b;
+
+// $pagination-active-border-color: #2d9782;
+
 /*-- scss:rules --*/
 
 .button {

--- a/css/lightstyle.scss
+++ b/css/lightstyle.scss
@@ -12,8 +12,6 @@ $pagination-color: #0b0b0b;
 $pagination-active-bg: #07eec0;
 $pagination-active-color: #0b0b0b;
 
-// $pagination-active-border-color: #2d9782;
-
 /*-- scss:rules --*/
 
 .button {

--- a/css/styles.css
+++ b/css/styles.css
@@ -65,3 +65,16 @@ make the footer border always appear.
 body .nav-footer {
   border-top: 1px solid #dee2e6;
 }
+
+/* Make an element invisible but focusable, e.g. for screen reader keyboard navigation */
+.jedi-hidden-and-focusable {
+  position: absolute !important;
+  width: 0px !important;
+  height: 0px !important;
+  padding: 0 !important;
+  margin: 0px !important;
+  border: 0 !important;
+  clip-path: inset(0px 0px) !important;
+  white-space: nowrap !important;
+  overflow: hidden !important;
+}

--- a/index.qmd
+++ b/index.qmd
@@ -29,6 +29,9 @@ https://twittercommunity.com/t/again-list-widget-says-nothing-to-see-here-yet-if
 ::: -->
 
 ```{=html}
+<h1 class='jedi-hidden-and-focusable'>
+  JEDI Outreach Group
+</h1>
 <img src="images/jedi-logo-wide.png" alt="Logo of the Justice, Equity, Diversity, and Inclusion Outreach Group" class="center">
 <p></p>
 <p></p>


### PR DESCRIPTION
See issue #29 for details. 

Updates made:

- Added an invisible level 1 heading for the main content on the home page (the logo image is serving as the "visible" heading). The invisible level 1 heading helps with keyboard navigation via screen readers (e.g. it shows up in the "Headings" menu). 
- Updated pagination buttons in the JEDI Corner section to conform to accessibility contrast guidelines. 
- Added section on "Accessibility Tips" to `CONTRIBUTING.md`. 
- Provided feedback for the Quarto team:
	- Starting at the top left image (or starting with the navigation landmark), the screen reader flows from the JEDI Outreach Group image and heading, then all the way right to the search icon, and *finally* to the individual page navigation links. It would be better if the screen reader flowed to the page navigation links before the search icon, as it is visually. Furthermore, the search icon takes three screen reader moves to get past (starting with entering a "combo box"), whereas one would be ideal. (Link: https://github.com/quarto-dev/quarto-cli/issues/7058)
	- A sidebar also adds a navigation Landmark. I think it would be useful for screen reader users if this shows up with a useful and unique label in keyboard navigation menus, e.g. perhaps by using something like `<nav aria-labelledby="sidebar navigation">`. (Link: https://github.com/quarto-dev/quarto-cli/issues/7059) 
		- Our [webinars listing page](https://datascijedi.org/jedi-corner) navigation seems to do this automatically, e.g. if you inspect the pagingation button you will see `<nav id="listing-pagination" class="listing-pagination" aria-label="Page Navigation">`
		- Our [activities](https://datascijedi.org/activities) page navigation is different and does _not_ automatically add the aria-label, e.g. if you inspect the link to the next subpage you will see only `<nav class="page-navigation">`. 