### PR TITLE
Fix to remove the pagination buttons

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -8,6 +8,7 @@ listing:
     contents: jedi-corner.yml
     max-items: 1
     sort: "date desc"
+    page-size: 0
 
   - id: jedi-webinars
     template: templates/jedi-webinar.ejs


### PR DESCRIPTION
This fixes the home page where pagination buttons started showing up for the JEDI Corner, when using Quarto v1.3.298. 

Resolves issue #126. 