### PR TITLE
Upgrade to Quarto v1.4.555

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -108,6 +108,7 @@ website:
           file: share-announcements.qmd
 
   page-footer:
+    border: true
     left: "Copyright 2023 © JEDI"
     center:
     - text: "GH-6c622c2fa6a54817" # placeholder text, replaced in post-render script

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -82,13 +82,11 @@ website:
         aria-label: GitHub
 
   sidebar:
-    # We use a dummy sidebar so that pages without a sidebar don't inherit an actual sidebar
-    - id: dummy-sidebar
-      border: true # Causes the separator to appear for the "Activities" sidebar
     - title: "Activities"
       style: "floating"
       collapse-level: 2
       align: left
+      border: true
       contents:
         - text: "Committees"
           file: activities.qmd
@@ -100,6 +98,7 @@ website:
       style: "floating"
       collapse-level: 2
       align: left
+      border: true
       contents:
         - text: "Get Involved"
           file: get-involved.qmd

--- a/css/darkstyle.scss
+++ b/css/darkstyle.scss
@@ -54,9 +54,3 @@ $pagination-active-color: #0b0b0b;
     background-color: #375a7f;
   }
 }
-
-// The override with $pagination-active-color is not working for the active link on dark theme,
-// so we manually override it here
-ul.pagination li.active a {
-  color: #0b0b0b;
-}

--- a/css/styles.css
+++ b/css/styles.css
@@ -57,15 +57,6 @@
   height: 100%;
 }
 
-/*
-Using a floating `sidebar` in Quarto sets the `floating` class on the `body` element, which in turn
-causes bootstrap to not apply `border-top` to `nav-footer`, so we use this work around to
-make the footer border always appear.
-*/
-body .nav-footer {
-  border-top: 1px solid #dee2e6;
-}
-
 /* 
 Unlike in Quarto v1.3.298, in Quarto v1.4.555 the footer elements are not vertically center aligned. 
 Below is a fix. 

--- a/css/styles.css
+++ b/css/styles.css
@@ -66,6 +66,19 @@ body .nav-footer {
   border-top: 1px solid #dee2e6;
 }
 
+/* 
+Unlike in Quarto v1.3.298, in Quarto v1.4.555 the footer elements are not vertically center aligned. 
+Below is a fix. 
+*/
+
+body .nav-footer {
+    align-items: center;
+}
+
+body .nav-footer-center {
+    min-height: 0px;
+}
+
 /* Make an element invisible but focusable, e.g. for screen reader keyboard navigation */
 .jedi-hidden-and-focusable {
   position: absolute !important;

--- a/netlify_deploy.sh
+++ b/netlify_deploy.sh
@@ -2,7 +2,7 @@
 
 # Set this URL to change the Quarto version for deploys
 # Quarto releases can be found here: https://github.com/quarto-dev/quarto-cli/releases/
-QUARTO_TARBALL_URL='https://github.com/quarto-dev/quarto-cli/releases/download/v1.3.298/quarto-1.3.298-linux-amd64.tar.gz'
+QUARTO_TARBALL_URL='https://github.com/quarto-dev/quarto-cli/releases/download/v1.4.555/quarto-1.4.555-linux-amd64.tar.gz'
 # The directory to render to. Should match specification in `netlify.toml`
 QUARTO_OUTPUT_DIR='_site'
 


### PR DESCRIPTION
This PR updates the website deployment to use the latest full release of Quarto, v1.4.555. This addresses issue #128 (with a slightly newer Quarto version than the one mentioned there). 

Anyone using Quarto to work on the website locally is encouraged to upgrade to the same version for consistent rendering. Releases for various platforms can be found here:

https://github.com/quarto-dev/quarto-cli/releases/download/v1.4.555

In addition, the [Quarto-related issue tracker](https://github.com/datascijedi/website/issues/115), which tracked issues that were blocked and waiting on external updates from the Quarto folks, is being retired in favor of using additional issues with appropriate labels for any outstanding and future Quarto-related issues. 