### PR TITLE
Implement no text wrap for the webinars date column

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -93,3 +93,9 @@ body .nav-footer-center {
   margin-right: 15px;
   margin-bottom: 15px;
 }
+
+/* Don't wrap date text in table column */
+
+tbody > tr > td:nth-of-type(1) {
+  white-space: nowrap;
+}


### PR DESCRIPTION
This fix removes text wrapping in the first webinars table column so that dates appear on one line rather than being wrapped to multiple lines. 

Addresses issue #139. 