### PR TITLE
Move date column css to webinars page

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -93,9 +93,3 @@ body .nav-footer-center {
   margin-right: 15px;
   margin-bottom: 15px;
 }
-
-/* Don't wrap date text in table column */
-
-tbody > tr > td:nth-of-type(1) {
-  white-space: nowrap;
-}

--- a/webinars.qmd
+++ b/webinars.qmd
@@ -20,6 +20,16 @@ page-layout: full
 toc: false
 ---
 
+```{=html}
+<style>
+/* Don't wrap date text in table column */
+
+tbody > tr > td:nth-of-type(1) {
+  white-space: nowrap;
+}
+</style>
+```
+
 ## Upcoming webinars
 
 New webinars are coming in 2024! Sign up for our [newsletter](weekly-newsletter.qmd) for the latest news on all JEDI Outreach Group activities. 


### PR DESCRIPTION
Move styling for no text wrapping on table date column to the webinars page, so that if additional `<table>` elements are added to the website in the future (e.g. via a Quarto listing type table), they will be unaffected by this styling unless they are also on the webinars page. 

Related Issue: #139 
Related PR: #141 