### PR TITLE
Update Quarto setup so that it's consistent for deployments, Codespaces, and Project IDX

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,12 @@
+FROM debian:12
+
+# COPY . .
+
+# Install Quarto
+RUN rm -rf ~/opt ~/bin
+RUN . ~/website/quarto_setup.sh
+
+# Install Git
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends git \
+    && git config --global --add safe.directory /workspaces/website

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,10 +1,7 @@
 FROM debian:12
 
-# COPY . .
-
 # Install Quarto
-RUN rm -rf ~/opt ~/bin
-RUN . ~/website/quarto_setup.sh
+RUN . /workspaces/website/quarto_setup.sh
 
 # Install Git
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,0 @@
-FROM debian:12
-
-# Install Git
-# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-#     && apt-get -y install --no-install-recommends git \
-#     && git config --global --add safe.directory /workspaces/website

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:12
 
 # Install Git
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends git \
-    && git config --global --add safe.directory /workspaces/website
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends git \
+#     && git config --global --add safe.directory /workspaces/website

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,5 @@
 FROM debian:12
 
-# Install Quarto
-RUN . /workspaces/website/quarto_setup.sh
-
 # Install Git
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends git \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,8 +6,9 @@
   "features": {
       "ghcr.io/devcontainers/features/common-utils:2": {
         "version": "latest"
-      }
-  },  
+      },
+      "ghcr.io/devcontainers/features/git:1": {}
+  },
   "customizations": {
     "vscode": {
       "extensions": ["quarto.quarto", "denoland.vscode-deno"]
@@ -17,5 +18,5 @@
     }
   },
   "forwardPorts": [4200],
-  "postCreateCommand": ". ./quarto_setup.sh"
+  "postCreateCommand": "bash ./quarto_setup.sh && export PATH=/root/bin/:$PATH"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,5 +18,8 @@
     }
   },
   "forwardPorts": [4200],
-  "postCreateCommand": "bash ./quarto_setup.sh && export PATH=/root/bin/:$PATH"
+  "postCreateCommand": "bash ./quarto_setup.sh",
+  "remoteEnv": {
+      "PATH": "/root/bin/:${containerEnv:PATH}"
+  }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,8 @@
 {
-  "name": "JEDI Outreach Group",
-  "image": "ghcr.io/quarto-dev/quarto:1.5.57",
+  "name": "DataSci JEDI Outreach Group",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
   "features": {
       "ghcr.io/devcontainers/features/common-utils:2": {
         "version": "latest"
@@ -14,6 +16,5 @@
       "openFiles": ["CONTRIBUTING.md"]
     }
   },
-  "forwardPorts": [4200],
-  "onCreateCommand": "apt update && apt install -y git && git config --global --add safe.directory /workspaces/website"
+  "forwardPorts": [4200]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,6 @@
 {
   "name": "DataSci JEDI Outreach Group",
-	"build": {
-		"dockerfile": "Dockerfile"
-	},
+  "image": "debian:12",
   "features": {
       "ghcr.io/devcontainers/features/common-utils:2": {
         "version": "latest"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,5 +16,6 @@
       "openFiles": ["CONTRIBUTING.md"]
     }
   },
-  "forwardPorts": [4200]
+  "forwardPorts": [4200],
+  "postCreateCommand": ". ./quarto_setup.sh"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 
 # Local Netlify folder
 .netlify
+
+# For any netlify_deploy.sh script artifacts
+quarto-1.5.57-linux-amd64.tar.gz*

--- a/.idx/dev.nix
+++ b/.idx/dev.nix
@@ -1,28 +1,22 @@
 { pkgs, ... }: {
-  channel = "unstable";
-
-  # Use https://search.nixos.org/packages to find packages
+  channel = "stable-24.05";
   packages = [
-    pkgs.quarto
   ];
-
-  env = {};
+  env = { PATH = ["/home/user/bin"]; };
   idx = {
-    # Search for the extensions you want on https://open-vsx.org/ and use "publisher.id"
     extensions = [
       "quarto.quarto"
     ];
-
-    # Enable previews
     previews = {
       enable = true;
     };
-
-    # Workspace lifecycle hooks
     workspace = {
-      # Runs when a workspace is first created
       onCreate = {
-        default.openFiles = [ "CONTRIBUTING.md" ];
+        install-quarto = ". /home/user/website/quarto_setup.sh";
+      };
+      onStart = {
+        remove-prior-quarto-installations = "rm -rf /home/user/opt /home/user/bin";
+        install-quarto = ". /home/user/website/quarto_setup.sh";
       };
     };
   };

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,18 +139,17 @@ Project IDX is a browser-based IDE which is currently in beta and available to u
 
 For more about Project IDX, check out: https://developers.google.com/idx/guides
 
-### Quarto Upgrade and Deployment
+### Quarto Version and Deployment
 
-The website is deployed with Netlify via [netlify_deploy.sh](https://github.com/datascijedi/website/blob/main/netlify_deploy.sh) and [netlify.toml](https://github.com/datascijedi/website/blob/main/netlify.toml). 
+The website is deployed with Netlify via [netlify.toml](https://github.com/datascijedi/website/blob/main/netlify.toml) in the repository root. 
 
-Below is a checklist for upgrading Quarto to a new version:
+Below is a checklist for udpating the Quarto version used in Netlify production deployments as well as Project IDX and Codespaces.
 
-1. Find the link for your desired Quarto version at https://github.com/quarto-dev/quarto-cli/releases. The file should end with `linux-amd64.tar.gz`.
-2. Update `QUARTO_TARBALL_URL` in `netlify_deploy.sh` in the repository root with the above mentioned link. This is what will be used in the production deployment.
+1. Find the desired version at https://github.com/quarto-dev/quarto-cli/releases. The file should end with `linux-amd64.tar.gz`. Note the version number, which should be in the form `#.#.#`.
+2. In `quarto_setup.sh`, update the version in `QUARTO_VERSION='1.5.57'`. Note that there is no "v" character preceding the version. 
 3. For Codespaces: Update the Quarto version specified in the `.devcontainer/devcontainer.json` file.
-4. For Project IDX: If you can find the right version by searching for "quarto" at https://search.nixos.org/packages, then update `.idx/dev.nix` in the repository root with the correct channel version (e.g. `channel = 24.05`), which will be in the top left of the NixOS website. If you can't find the correct Quarto version, try clicking "unstable" on the NixOS website, and search for quarto again. If you find a better fit (e.g. the right version, or a newer version than what was being used), then replace the channel version with "unsable" (e.g. `channel = unstable`).
 
-If you get stuck on the above (which could happen, for instance, if the process evolves abruptly), feel free to reach out to one of the current or past contributors for help!
+Please feel free to create an issue if you run into any problems. Thanks! 
 
 ## JEDI Membership
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,7 @@ Codespaces is a browser-based IDE that currently provides 60 hours of usage free
 
 1) [Navigate to the repository](https://github.com/datascijedi/website) on GitHub.
 2) Click the Code button, and create or open a Codespace from there. 
-3) If needed, open up the integrated terminal, then run `quarto preview` to start up the Quarto dev server.
+3) If needed, open up the integrated terminal, wait for any loading to finish, then run `quarto preview` to start up the Quarto dev server.
 4) At this point, you should be presented with a button to open up a development version of the website in your browser, which should reflect any changes you make. 
 
 For more on Codespaces, check out:
@@ -134,7 +134,7 @@ Project IDX is a browser-based IDE which is currently in beta and available to u
 
 1) Go to https://idx.dev/. Click on "Get Started" in the top right, creating an account as necessary. If you are already a Google/Gmail user and currently logged in, the default behavior might be to sign you in with the same account.
 2) Click on "Import a repo" on the right hand side, enter in the GitHub repository URL (https://github.com/datascijedi/website), and then click the "Import" button which should open up the IDE.
-3) Open up the integrated terminal _(Horizontal Striped Menu -> View -> Terminal)_ and run `quarto preview` to start up the Quarto dev server.
+3) Wait for any loading to finish, open up the integrated terminal _(Horizontal Striped Menu -> View -> Terminal)_ and run `quarto preview` to start up the Quarto dev server.
 4) Click on the "Project IDX" button on the left side of the window (the bottom button, it looks like an arrow facing right), expand "BACKEND PORTS" at the bottom of the opened side panel, and click the button to open the preview URL which should reflect any changes you make.
 
 For more about Project IDX, check out: https://developers.google.com/idx/guides
@@ -143,11 +143,11 @@ For more about Project IDX, check out: https://developers.google.com/idx/guides
 
 The website is deployed with Netlify via [netlify.toml](https://github.com/datascijedi/website/blob/main/netlify.toml) in the repository root. 
 
-Below is a checklist for udpating the Quarto version used in Netlify production deployments as well as Project IDX and Codespaces.
+Below is a checklist for udpating the Quarto version used in Netlify production deployments, as well as Project IDX and Codespaces.
 
-1. Find the desired version at https://github.com/quarto-dev/quarto-cli/releases. The file should end with `linux-amd64.tar.gz`. Note the version number, which should be in the form `#.#.#`.
-2. In `quarto_setup.sh`, update the version in `QUARTO_VERSION='1.5.57'`. Note that there is no "v" character preceding the version. 
-3. For Codespaces: Update the Quarto version specified in the `.devcontainer/devcontainer.json` file.
+1. Find your desired Quarto version at https://github.com/quarto-dev/quarto-cli/releases. The file should end with `linux-amd64.tar.gz`. Note the version number, which should be in the form `#.#.#`.
+2. In `quarto_setup.sh`, update the version in `QUARTO_VERSION='1.5.57'`. Note that there is no "v" character preceding the version used here.
+3. In `README.md`, update the version in the badge url, e.g. https://img.shields.io/badge/Quarto-v1.5.57-green.
 
 Please feel free to create an issue if you run into any problems. Thanks! 
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <p align="center"><img src="./images/jedi-logo-wide.png" alt="jedi-logo-wide" width="300"/></p>
 
+<p align="center"><img src="https://img.shields.io/badge/Quarto-v1.5.57-green " alt="quarto-version"/></p>
+
 This repository holds the source files for our live website at https://datascijedi.org. 
 
 If you'd like to contribute content or code to the website, please check out our [contributor documentation](https://github.com/datascijedi/website/blob/main/CONTRIBUTING.md). 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center"><img src="./images/jedi-logo-wide.png" alt="jedi-logo-wide" width="300"/></p>
 
-<p align="center"><img src="https://img.shields.io/badge/Quarto-v1.5.57-green " alt="quarto-version"/></p>
+<p align="center"><img src="https://img.shields.io/badge/Quarto-v1.5.57-green" alt="quarto-version"/></p>
 
 This repository holds the source files for our live website at https://datascijedi.org. 
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,3 @@
 [build]
 	publish = "_site"
-	command = ". quarto_install.sh"
+	command = ". quarto_setup.sh"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,3 @@
 [build]
 	publish = "_site"
-	command = ". netlify_deploy.sh"
+	command = ". quarto_install.sh"

--- a/quarto_setup.sh
+++ b/quarto_setup.sh
@@ -31,7 +31,7 @@ export PATH=~/bin:$PATH
 rm ${QUARTO_TARBALL_BASENAME}
 
 # Only render up front for production deployments (not for Project IDX or Codespaces)
-if [ -z ${IDX_CHANNEL} -a -z ${CODESPACE_VSCODE_FOLDER} ]; then
+if [ -z ${IDX_CHANNEL} ] && [ -z ${CODESPACE_VSCODE_FOLDER} ]; then
   quarto render --output-dir ${QUARTO_OUTPUT_DIR}
 fi
 

--- a/quarto_setup.sh
+++ b/quarto_setup.sh
@@ -1,23 +1,38 @@
 # Sets up Quarto and renders the website
 
-# Set this URL to change the Quarto version for deploys
+echo "Quarto setup has begun. Please wait until it's ready to start using Quarto."
+
+# Set the version of Quarto using the form `#.#.#.` and omitting any preceding "v" character
 # Quarto releases can be found here: https://github.com/quarto-dev/quarto-cli/releases/
-QUARTO_TARBALL_URL='https://github.com/quarto-dev/quarto-cli/releases/download/v1.5.57/quarto-1.5.57-linux-amd64.tar.gz'
+QUARTO_VERSION='1.5.57'
+
+# Set this URL to change the Quarto version for deploys
+QUARTO_TARBALL_URL=https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz
+
 # The directory to render to. Should match specification in `netlify.toml`
 QUARTO_OUTPUT_DIR='_site'
 
 QUARTO_TARBALL_BASENAME=${QUARTO_TARBALL_URL##*/}
 QUARTO_SHORT_NAME=${QUARTO_TARBALL_BASENAME%-linux-amd64.tar.gz}
 
+# Download Quarto
 wget ${QUARTO_TARBALL_URL} &> /dev/null
 if [ ! -f ${QUARTO_TARBALL_BASENAME} ]; then
   echo 'ERROR: Quarto tarball is missing, please check QUARTO_TARBALL_URL.'
   exit 1
 fi
 
+# Install Quarto
 mkdir ~/opt
 tar -C ~/opt -xvzf ${QUARTO_TARBALL_BASENAME} &> /dev/null
 mkdir ~/bin
 ln -s ~/opt/${QUARTO_SHORT_NAME}/bin/quarto ~/bin/quarto
-export PATH=$PATH:~/bin
-quarto render --output-dir ${QUARTO_OUTPUT_DIR}
+export PATH=~/bin:$PATH
+rm ${QUARTO_TARBALL_BASENAME}
+
+# Only render up front if we are not in Project IDX
+if [ -z ${IDX_CHANNEL} ]; then
+  quarto render --output-dir ${QUARTO_OUTPUT_DIR}
+fi
+
+echo "Quarto setup is ready."

--- a/quarto_setup.sh
+++ b/quarto_setup.sh
@@ -30,8 +30,8 @@ ln -s ~/opt/${QUARTO_SHORT_NAME}/bin/quarto ~/bin/quarto
 export PATH=~/bin:$PATH
 rm ${QUARTO_TARBALL_BASENAME}
 
-# Only render up front if we are not in Project IDX
-if [ -z ${IDX_CHANNEL} ]; then
+# Only render up front for production deployments (not for Project IDX or Codespaces)
+if [ -z ${IDX_CHANNEL} -a -z ${CODESPACE_VSCODE_FOLDER} ]; then
   quarto render --output-dir ${QUARTO_OUTPUT_DIR}
 fi
 


### PR DESCRIPTION
Addresses issue #155. 

Adjusts configuration so that deployments to Netlify, as well as the online IDEs (Codepsaces, and Project IDX) all use the same script to set up Quarto, `quarto_setup.sh`. Hence, any future updates to the Quarto version should apply to all three environments mentioned. 